### PR TITLE
Removed function update_last_removed left over from Drupal 7 port.

### DIFF
--- a/book_made_simple.install
+++ b/book_made_simple.install
@@ -18,15 +18,6 @@ function book_made_simple_install() {
 }
 
 /**
- * Implements hook_update_last_removed().
- *
- * @return int
- */
-function book_made_simple_update_last_removed() {
-  return 6013;
-}
-
-/**
  * Upgrade variables to configuration and remove unneeded variables.
  */
 function book_made_simple_update_1000() {


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/book_made_simple/issues/4